### PR TITLE
BUG: Configuration Schema not being used

### DIFF
--- a/Tuxboard.Core/Data/Configuration/DashboardConfiguration.cs
+++ b/Tuxboard.Core/Data/Configuration/DashboardConfiguration.cs
@@ -20,7 +20,7 @@ public class DashboardConfiguration : IEntityTypeConfiguration<Dashboard>
 
     public void Configure(EntityTypeBuilder<Dashboard> builder)
     {
-        builder.ToTable("Dashboard");
+        builder.ToTable("Dashboard", _config.Schema);
 
         builder.Property(e => e.DashboardId)
             .HasMaxLength(36)

--- a/Tuxboard.Core/Data/Configuration/DashboardDefaultConfiguration.cs
+++ b/Tuxboard.Core/Data/Configuration/DashboardDefaultConfiguration.cs
@@ -23,7 +23,7 @@ public class DashboardDefaultConfiguration : IEntityTypeConfiguration<DashboardD
     {
         builder.HasKey(e => e.DefaultId);
 
-        builder.ToTable("DashboardDefault");
+        builder.ToTable("DashboardDefault", _config.Schema);
 
         builder.HasIndex(e => e.LayoutId, "IX_DashboardDefault_LayoutId");
 

--- a/Tuxboard.Core/Data/Configuration/DashboardDefaultWidgetConfiguration.cs
+++ b/Tuxboard.Core/Data/Configuration/DashboardDefaultWidgetConfiguration.cs
@@ -23,7 +23,7 @@ public class DashboardDefaultWidgetConfiguration : IEntityTypeConfiguration<Dash
     {
         builder.HasKey(e => e.DefaultWidgetId);
 
-        builder.ToTable("DashboardDefaultWidget");
+        builder.ToTable("DashboardDefaultWidget", _config.Schema);
 
         builder.HasIndex(e => e.DashboardDefaultId, "IX_DashboardDefaultWidget_DashboardDefaultId");
 

--- a/Tuxboard.Core/Data/Configuration/DashboardTabConfiguration.cs
+++ b/Tuxboard.Core/Data/Configuration/DashboardTabConfiguration.cs
@@ -22,7 +22,7 @@ public class DashboardTabConfiguration : IEntityTypeConfiguration<DashboardTab>
     {
         builder.HasKey(e => e.TabId);
 
-        builder.ToTable("DashboardTab");
+        builder.ToTable("DashboardTab", _config.Schema);
 
         builder.HasIndex(e => e.DashboardId, "IX_DashboardTab_DashboardId");
 

--- a/Tuxboard.Core/Data/Configuration/LayoutConfiguration.cs
+++ b/Tuxboard.Core/Data/Configuration/LayoutConfiguration.cs
@@ -21,7 +21,7 @@ public class LayoutConfiguration : IEntityTypeConfiguration<Layout>
 
     public void Configure(EntityTypeBuilder<Layout> builder)
     {
-        builder.ToTable("Layout");
+        builder.ToTable("Layout", _config.Schema);
 
         builder.HasIndex(e => e.TabId, "IX_Layout_TabId");
 

--- a/Tuxboard.Core/Data/Configuration/LayoutRowConfiguration.cs
+++ b/Tuxboard.Core/Data/Configuration/LayoutRowConfiguration.cs
@@ -21,7 +21,7 @@ public class LayoutRowConfiguration : IEntityTypeConfiguration<LayoutRow>
 
     public void Configure(EntityTypeBuilder<LayoutRow> builder)
     {
-        builder.ToTable("LayoutRow");
+        builder.ToTable("LayoutRow", _config.Schema);
 
         builder.HasIndex(e => e.LayoutId, "IX_LayoutRow_LayoutId");
 

--- a/Tuxboard.Core/Data/Configuration/LayoutTypeConfiguration.cs
+++ b/Tuxboard.Core/Data/Configuration/LayoutTypeConfiguration.cs
@@ -21,7 +21,7 @@ public class LayoutTypeConfiguration : IEntityTypeConfiguration<LayoutType>
 
     public void Configure(EntityTypeBuilder<LayoutType> builder)
     {
-        builder.ToTable("LayoutType");
+        builder.ToTable("LayoutType", _config.Schema);
 
         builder.Property(e => e.Layout)
             .IsRequired()

--- a/Tuxboard.Core/Data/Configuration/PlanConfiguration.cs
+++ b/Tuxboard.Core/Data/Configuration/PlanConfiguration.cs
@@ -20,7 +20,7 @@ public class PlanConfiguration : IEntityTypeConfiguration<Plan>
 
     public void Configure(EntityTypeBuilder<Plan> builder)
     {
-        builder.ToTable("Plan");
+        builder.ToTable("Plan", _config.Schema);
 
         builder.Property(e => e.Title)
             .IsRequired()

--- a/Tuxboard.Core/Data/Configuration/WidgetConfiguration.cs
+++ b/Tuxboard.Core/Data/Configuration/WidgetConfiguration.cs
@@ -21,7 +21,7 @@ public class WidgetConfiguration : IEntityTypeConfiguration<Widget>
 
     public void Configure(EntityTypeBuilder<Widget> builder)
     {
-        builder.ToTable("Widget");
+        builder.ToTable("Widget", _config.Schema);
 
         builder.Property(e => e.WidgetId)
             .HasMaxLength(36)

--- a/Tuxboard.Core/Data/Configuration/WidgetDefaultConfiguration.cs
+++ b/Tuxboard.Core/Data/Configuration/WidgetDefaultConfiguration.cs
@@ -21,7 +21,7 @@ public class WidgetDefaultConfiguration : IEntityTypeConfiguration<WidgetDefault
 
     public void Configure(EntityTypeBuilder<WidgetDefault> builder)
     {
-        builder.ToTable("WidgetDefault");
+        builder.ToTable("WidgetDefault", _config.Schema);
 
         builder.HasIndex(e => e.WidgetId, "IX_WidgetDefault_WidgetId");
 

--- a/Tuxboard.Core/Data/Configuration/WidgetDefaultOptionConfiguration.cs
+++ b/Tuxboard.Core/Data/Configuration/WidgetDefaultOptionConfiguration.cs
@@ -23,7 +23,7 @@ public class WidgetDefaultOptionConfiguration : IEntityTypeConfiguration<WidgetD
         builder.HasKey(e => e.WidgetOptionId)
             .HasName("PK_WidgetSettingOption");
 
-        builder.ToTable("WidgetDefaultOption");
+        builder.ToTable("WidgetDefaultOption", _config.Schema);
 
         builder.HasIndex(e => e.WidgetDefaultId, "IX_WidgetDefaultOption_WidgetDefaultId");
 

--- a/Tuxboard.Core/Data/Configuration/WidgetPlacementConfiguration.cs
+++ b/Tuxboard.Core/Data/Configuration/WidgetPlacementConfiguration.cs
@@ -20,7 +20,7 @@ public class WidgetPlacementConfiguration : IEntityTypeConfiguration<WidgetPlace
 
     public void Configure(EntityTypeBuilder<WidgetPlacement> builder)
     {
-        builder.ToTable("WidgetPlacement");
+        builder.ToTable("WidgetPlacement", _config.Schema);
 
         builder.HasIndex(e => e.LayoutRowId, "IX_WidgetPlacement_LayoutRowId");
 

--- a/Tuxboard.Core/Data/Configuration/WidgetSettingConfiguration.cs
+++ b/Tuxboard.Core/Data/Configuration/WidgetSettingConfiguration.cs
@@ -20,7 +20,7 @@ public class WidgetSettingConfiguration : IEntityTypeConfiguration<WidgetSetting
 
     public void Configure(EntityTypeBuilder<WidgetSetting> builder)
     {
-        builder.ToTable("WidgetSetting");
+        builder.ToTable("WidgetSetting", _config.Schema);
 
         builder.HasIndex(e => e.WidgetDefaultId, "IX_WidgetSetting_WidgetDefaultId");
 

--- a/Tuxboard.Core/Tuxboard.Core.nuspec
+++ b/Tuxboard.Core/Tuxboard.Core.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
 	<metadata>
 		<id>Tuxboard.Core</id>
-		<version>1.7.1</version>
+		<version>1.7.2</version>
 		<authors>Jonathan "JD" Danylko</authors>
 		<owners>Jonathan "JD" Danylko</owners>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
While configuration was passed into the DbContext, the schema was omitted from the `.ToTable()` method.