### PR TITLE
Remove .NET 9.0 references

### DIFF
--- a/Tuxboard.Core/Tuxboard.Core.nuspec
+++ b/Tuxboard.Core/Tuxboard.Core.nuspec
@@ -26,6 +26,5 @@
 	</metadata>
 	<files>
 		<file src="bin\Release\net10.0\Tuxboard.Core.dll" target="lib\net10.0\Tuxboard.Core.dll" />
-		<file src="bin\Release\net9.0\Tuxboard.Core.dll" target="lib\net9.0\Tuxboard.Core.dll" />
 	</files>
 </package>


### PR DESCRIPTION
- Removed .NET 9.0 references; Only using the most current version of .NET from this point forward